### PR TITLE
Add unit tests for helpermock.call.RequestMock

### DIFF
--- a/heimdall-middleware-spec/src/test/java/br/com/conductor/heimdall/middleware/util/helpermock/call/RequestMockTest.java
+++ b/heimdall-middleware-spec/src/test/java/br/com/conductor/heimdall/middleware/util/helpermock/call/RequestMockTest.java
@@ -1,0 +1,50 @@
+package br.com.conductor.heimdall.middleware.util.helpermock.call;
+
+import org.junit.Test;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+
+public class RequestMockTest {
+
+  @Test
+  public void testHeader() {
+    final RequestMock requestMock = new RequestMock();
+    assertEquals(new HashMap<String, String>(), requestMock.header().getAll());
+  }
+
+  @Test
+  public void testQuery() {
+    final RequestMock requestMock = new RequestMock();
+    assertEquals(new HashMap<String, String>(), requestMock.query().getAll());
+  }
+
+  @Test
+  public void testSetAppName() {
+    final RequestMock requestMock = new RequestMock();
+    requestMock.setAppName("testName");
+    assertEquals("testName", requestMock.getAppName());
+  }
+
+  @Test
+  public void testSetBody() {
+    final RequestMock requestMock = new RequestMock();
+    requestMock.setBody("testBody");
+    assertEquals("testBody", requestMock.getBody());
+  }
+
+  @Test
+  public void testSetUrl() {
+    final RequestMock requestMock = new RequestMock();
+    requestMock.setUrl("www.google.com");
+    assertEquals("www.google.com", requestMock.getUrl());
+  }
+
+  @Test
+  public void testPathParam() {
+    final RequestMock requestMock = new RequestMock();
+    assertNull(requestMock.pathParam("testPath"));
+  }
+}


### PR DESCRIPTION
Hi,

I've analysed your code base and noticed that:
`br.com.conductor.heimdall.middleware.util.helpermock.call.RequestMock` 
in the heimdall-middleware-spec module is not fully tested.

I've written some tests that cover this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.