### PR TITLE
Add unit tests for CalendarUtils, DigestUtils, StringUtils and UrlUtil

### DIFF
--- a/heimdall-core/src/test/java/br/com/conductor/heimdall/core/util/CalendarUtilsTest.java
+++ b/heimdall-core/src/test/java/br/com/conductor/heimdall/core/util/CalendarUtilsTest.java
@@ -1,0 +1,58 @@
+package br.com.conductor.heimdall.core.util;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-core
+ * ========================================================================
+ * Copyright (C) 2019 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import java.time.LocalDate;
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CalendarUtilsTest {
+
+    @Test
+    public void testFirstAndLastDaysOfWeek() {
+        HashMap<String, LocalDate> week1 = new HashMap<>();
+        week1.put("first", LocalDate.of(2019, 7, 8));
+        week1.put("last", LocalDate.of(2019, 7, 14));
+
+        HashMap<String, LocalDate> week2 = new HashMap<>();
+        week2.put("first", LocalDate.of(2019, 7, 1));
+        week2.put("last", LocalDate.of(2019, 7, 7));
+
+        Assert.assertEquals(week1, CalendarUtils.firstAndLastDaysOfWeek(
+                LocalDate.of(2019, 7, 8)));
+        Assert.assertEquals(week2, CalendarUtils.firstAndLastDaysOfWeek(
+                LocalDate.of(2019, 7, 7)));
+    }
+
+    @Test
+    public void testYearAndMonth() {
+        Assert.assertEquals("2019-02",
+                CalendarUtils.yearAndMonth(LocalDate.of(2019, 2, 8)));
+    }
+
+    @Test
+    public void testYear() {
+        Assert.assertEquals("2019",
+                CalendarUtils.year(LocalDate.of(2019, 2, 8)));
+    }
+}

--- a/heimdall-core/src/test/java/br/com/conductor/heimdall/core/util/DigestUtilsTest.java
+++ b/heimdall-core/src/test/java/br/com/conductor/heimdall/core/util/DigestUtilsTest.java
@@ -1,0 +1,36 @@
+package br.com.conductor.heimdall.core.util;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-core
+ * ========================================================================
+ * Copyright (C) 2019 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DigestUtilsTest {
+
+    @Test
+    public void testDigestMD5() {
+        Assert.assertNull(DigestUtils.digestMD5(null));
+
+        Assert.assertEquals("", DigestUtils.digestMD5(""));
+        Assert.assertEquals("acbd18db4cc2f85cedef654fccc4a4d8",
+                DigestUtils.digestMD5("foo"));
+    }
+}

--- a/heimdall-core/src/test/java/br/com/conductor/heimdall/core/util/StringUtilsTest.java
+++ b/heimdall-core/src/test/java/br/com/conductor/heimdall/core/util/StringUtilsTest.java
@@ -1,0 +1,46 @@
+package br.com.conductor.heimdall.core.util;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-core
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    public void testGenerateOrder() {
+        Assert.assertEquals("104", StringUtils.generateOrder(1, 4));
+    }
+
+    @Test
+    public void testConcatCamelCase() {
+        Assert.assertEquals("FooBarBaz",
+                StringUtils.concatCamelCase("foo", "bar", "baz"));
+        Assert.assertEquals("FOOBARBAZ",
+                StringUtils.concatCamelCase("f_o_o", "b_a_r", "b_a_z"));
+    }
+
+    @Test
+    public void testRemoveMultipleSlashes() {
+        Assert.assertEquals("/foo/+bar/+baz",
+                StringUtils.removeMultipleSlashes("foo//+bar//+baz"));
+    }
+}

--- a/heimdall-core/src/test/java/br/com/conductor/heimdall/core/util/UrlUtilTest.java
+++ b/heimdall-core/src/test/java/br/com/conductor/heimdall/core/util/UrlUtilTest.java
@@ -1,0 +1,59 @@
+package br.com.conductor.heimdall.core.util;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-core
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public class UrlUtilTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testGetCurrentUrl() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/foo");
+        request.setQueryString("param1=value1&param");
+
+        Assert.assertNull(UrlUtil.getCurrentUrl(null));
+
+        Assert.assertEquals("http://localhost/foo?param1=value1&param",
+                UrlUtil.getCurrentUrl(request));
+        Assert.assertEquals("http://localhost",
+                UrlUtil.getCurrentUrl(new MockHttpServletRequest()));
+    }
+
+    @Test
+    public void testGetUrl() throws MalformedURLException {
+        Assert.assertEquals(new URL("https://www.foo.com"),
+                UrlUtil.getUrl("https://www.foo.com"));
+
+        thrown.expect(IllegalStateException.class);
+        UrlUtil.getUrl("foo");
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `CalendarUtils, DigestUtils, StringUtils and UrlUtil` from package `br.com.conductor.heimdall.core.util` are not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.